### PR TITLE
encode strings using encodeURIComponent()

### DIFF
--- a/src/app/views/home.js
+++ b/src/app/views/home.js
@@ -14,7 +14,7 @@ export default {
 		},
 
 		slug () {
-			return this.text.replace(/\s+/g, '_')
+			return encodeURIComponent(this.text)
 		},
 	},
 
@@ -34,7 +34,7 @@ export default {
 		const query = this.$route.query
 
 		if (Object.keys(query).length !== 0)
-			this.text = query.q.replace(/_/g, ' ')
+			this.text = query.q
 
 		this.update()
 	},


### PR DESCRIPTION
This prevents confusing underscores with spaces at the cost of less readable URLs.

Not sure if you want this.